### PR TITLE
Add "Junk Berserker (anime)"

### DIFF
--- a/c511027027.lua
+++ b/c511027027.lua
@@ -1,0 +1,52 @@
+--ジャンク・バーサーカー (アニメ)
+--Junk Berserker (Anime)
+--Scripted By Sever666
+local s,id=GetID()
+function s.initial_effect(c)
+	--synchro summon
+	Synchro.AddProcedure(c,s.tfilter,1,1,Synchro.NonTuner(nil),1,99)
+	c:EnableReviveLimit()
+	--atkdown
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(s.cost)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+s.listed_series={0x43}
+s.material_setcode=0x1017
+function s.tfilter(c,lc,stype,tp)
+	return c:IsSummonCode(lc,stype,tp,63977008) or c:IsHasEffect(20932152)
+end
+function s.cfilter(c)
+	return c:IsSetCard(0x43) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
+end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil)
+	e:SetLabel(g:GetFirst():GetAttack())
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(-e:GetLabel())
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e1)
+	end
+end


### PR DESCRIPTION
https://yugipedia.com/wiki/Junk_Berserker_(anime)

actually i wanted to add the anime version of "Junk Berserker" to the game to support the anime players cuz i am one of them its not fair for junk berserker in accurate character deck duel, to have an effect that destroy the defense position monsters while in the anime he hadn't , also in the anime he's attack/defense was 2500/1800 not 2700/1800 and this is was an other reason to do the anime version of him
thx
(sorry for my faults)